### PR TITLE
.Net 8 Support and Library Cleanup

### DIFF
--- a/PD2Launcherv2/MainWindow.xaml.cs
+++ b/PD2Launcherv2/MainWindow.xaml.cs
@@ -1,5 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
-using GalaSoft.MvvmLight.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;
 using PD2Shared.Helpers;
@@ -135,8 +135,8 @@ namespace PD2Launcherv2
             LoadConfiguration();
 
             // Registering to receive NavigationMessage
-            Messenger.Default.Register<NavigationMessage>(this, OnNavigationMessageReceived);
-            Messenger.Default.Register<ConfigurationChangeMessage>(this, OnConfigurationChanged);
+            WeakReferenceMessenger.Default.Register<NavigationMessage>(this, (recipient, message) => OnNavigationMessageReceived(message));
+            WeakReferenceMessenger.Default.Register<ConfigurationChangeMessage>(this, (recipient, message) => OnConfigurationChanged(message));
             DataContext = this;
 
             this.Closed += MainWindow_Closed;

--- a/PD2Launcherv2/MainWindow.xaml.cs
+++ b/PD2Launcherv2/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight.Command;
+﻿using CommunityToolkit.Mvvm.Input;
 using GalaSoft.MvvmLight.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;

--- a/PD2Launcherv2/PD2Launcherv2.csproj
+++ b/PD2Launcherv2/PD2Launcherv2.csproj
@@ -17,7 +17,7 @@
     <PublishDir>..\bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <SelfContained>false</SelfContained>
     <_IsPortable>true</_IsPortable>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
@@ -76,7 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.2.24128.5" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="sharpconfig" Version="3.2.9.1" />
     <PackageReference Include="WpfAnimatedGif" Version="2.0.2" />
   </ItemGroup>

--- a/PD2Launcherv2/PD2Launcherv2.csproj
+++ b/PD2Launcherv2/PD2Launcherv2.csproj
@@ -75,7 +75,6 @@
     <PackageReference Include="MadMilkman.Ini" Version="1.0.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3485.44" />
-    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="sharpconfig" Version="3.2.9.1" />
     <PackageReference Include="WpfAnimatedGif" Version="2.0.2" />

--- a/PD2Launcherv2/PD2Launcherv2.csproj
+++ b/PD2Launcherv2/PD2Launcherv2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
@@ -71,10 +70,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="MadMilkman.Ini" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.2.24128.5" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3485.44" />
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="sharpconfig" Version="3.2.9.1" />

--- a/PD2Launcherv2/ViewModels/AboutViewModel.cs
+++ b/PD2Launcherv2/ViewModels/AboutViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
-using GalaSoft.MvvmLight.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;
 using PD2Shared.Interfaces;
@@ -76,9 +76,9 @@ namespace PD2Launcherv2.ViewModels
             };
             _localStorage.Update(StorageKey.FileUpdateModel, fileUpdateModel);
             var launcherArgs = _localStorage.LoadSection<LauncherArgs>(StorageKey.LauncherArgs);
-            Messenger.Default.Send(new ConfigurationChangeMessage { IsBeta = false , IsCustom = false, IsDisableUpdates = launcherArgs.disableAutoUpdate});
+            WeakReferenceMessenger.Default.Send(new ConfigurationChangeMessage { IsBeta = false , IsCustom = false, IsDisableUpdates = launcherArgs.disableAutoUpdate});
             Debug.WriteLine("end ProdBucketAssign\n");
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
         public void BetaBucketAssign()
         {
@@ -92,9 +92,9 @@ namespace PD2Launcherv2.ViewModels
             _localStorage.Update(StorageKey.FileUpdateModel, fileUpdateModel);
             var launcherArgs = _localStorage.LoadSection<LauncherArgs>(StorageKey.LauncherArgs);
 
-            Messenger.Default.Send(new ConfigurationChangeMessage { IsBeta = true , IsCustom = false , IsDisableUpdates = launcherArgs.disableAutoUpdate });
+            WeakReferenceMessenger.Default.Send(new ConfigurationChangeMessage { IsBeta = true , IsCustom = false , IsDisableUpdates = launcherArgs.disableAutoUpdate });
             Debug.WriteLine("end BetaBucketAssign \n");
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
 
         private void CustomBucketAssign()
@@ -123,20 +123,20 @@ namespace PD2Launcherv2.ViewModels
 
             var launcherArgs = _localStorage.LoadSection<LauncherArgs>(StorageKey.LauncherArgs);
 
-            Messenger.Default.Send(new ConfigurationChangeMessage
+            WeakReferenceMessenger.Default.Send(new ConfigurationChangeMessage
             {
                 IsBeta = false,
                 IsCustom = false,
                 IsDisableUpdates = launcherArgs.disableAutoUpdate
             });
-            Messenger.Default.Send(new ConfigurationChangeMessage { IsBeta = false, IsCustom = true, IsDisableUpdates = launcherArgs.disableAutoUpdate });
+            WeakReferenceMessenger.Default.Send(new ConfigurationChangeMessage { IsBeta = false, IsCustom = true, IsDisableUpdates = launcherArgs.disableAutoUpdate });
             Debug.WriteLine("end SetCustomEnvironment\n");
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
 
         private void CloseView()
         {
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
     }
 }

--- a/PD2Launcherv2/ViewModels/AboutViewModel.cs
+++ b/PD2Launcherv2/ViewModels/AboutViewModel.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight.Command;
+﻿using CommunityToolkit.Mvvm.Input;
 using GalaSoft.MvvmLight.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;

--- a/PD2Launcherv2/ViewModels/FiltersViewModel.cs
+++ b/PD2Launcherv2/ViewModels/FiltersViewModel.cs
@@ -1,4 +1,4 @@
-﻿using GalaSoft.MvvmLight.Command;
+﻿using CommunityToolkit.Mvvm.Input;
 using GalaSoft.MvvmLight.Messaging;
 using Microsoft.Web.WebView2.Wpf;
 using PD2Launcherv2.Enums;

--- a/PD2Launcherv2/ViewModels/FiltersViewModel.cs
+++ b/PD2Launcherv2/ViewModels/FiltersViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
-using GalaSoft.MvvmLight.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Web.WebView2.Wpf;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;
@@ -368,7 +368,7 @@ namespace PD2Launcherv2.ViewModels
 
         private void CloseView()
         {
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
 
         private async void SaveFilterExecute()
@@ -383,7 +383,7 @@ namespace PD2Launcherv2.ViewModels
                     // Update storage to reflect the new or updated filter
                     SaveFilterToStorage();
                     Debug.WriteLine("Filter applied");
-                    Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+                    WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
                 }
                 else
                 {

--- a/PD2Launcherv2/ViewModels/OptionsViewModel.cs
+++ b/PD2Launcherv2/ViewModels/OptionsViewModel.cs
@@ -1,5 +1,5 @@
 using CommunityToolkit.Mvvm.Input;
-using GalaSoft.MvvmLight.Messaging;
+using CommunityToolkit.Mvvm.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;
 using PD2Shared.Interfaces;
@@ -515,7 +515,7 @@ namespace PD2Launcherv2.ViewModels
                     OnPropertyChanged();
                     var fileUpdateMode = _localStorage.LoadSection<FileUpdateModel>(StorageKey.FileUpdateModel);
                     bool amIBeta = fileUpdateMode.FilePath.Equals("Beta");
-                    Messenger.Default.Send(new ConfigurationChangeMessage { IsDisableUpdates = value, IsBeta = amIBeta });
+                    WeakReferenceMessenger.Default.Send(new ConfigurationChangeMessage { IsDisableUpdates = value, IsBeta = amIBeta });
                 }
             }
         }
@@ -775,7 +775,7 @@ namespace PD2Launcherv2.ViewModels
             _ddrawHelpers.WriteDdrawOptions();
 
             // Sending a message to anyone who's listening for NavigationMessage
-            Messenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
+            WeakReferenceMessenger.Default.Send(new NavigationMessage { Action = NavigationAction.GoBack });
         }
     }
 }

--- a/PD2Launcherv2/ViewModels/OptionsViewModel.cs
+++ b/PD2Launcherv2/ViewModels/OptionsViewModel.cs
@@ -1,4 +1,4 @@
-using GalaSoft.MvvmLight.Command;
+using CommunityToolkit.Mvvm.Input;
 using GalaSoft.MvvmLight.Messaging;
 using PD2Launcherv2.Enums;
 using PD2Launcherv2.Helpers;

--- a/PD2Shared/PD2Shared.csproj
+++ b/PD2Shared/PD2Shared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <OutputType>Library</OutputType>
-      <TargetFramework>net6.0-windows</TargetFramework>
+      <TargetFramework>net8.0-windows</TargetFramework>
       <Nullable>enable</Nullable>
       <ImplicitUsings>enable</ImplicitUsings>
       <IsPublishable>True</IsPublishable>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="MadMilkman.Ini" Version="1.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/SteamPD2/SteamPD2.csproj
+++ b/SteamPD2/SteamPD2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\Icons\icon.ico</ApplicationIcon>

--- a/UpdateUtility/UpdateUtility.csproj
+++ b/UpdateUtility/UpdateUtility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPublishable>True</IsPublishable>


### PR DESCRIPTION
I changed the builds to target x86 .net 8 instead of the EoL 6 with no behavior change.

I also wrote out the deprecated Galasoft MVMM library and inserted the MS maintained CommunityToolkit package. No behavior changes with this one either.