### PR TITLE
Close launcher after launching the game with --launch arg

### DIFF
--- a/PD2Launcherv2/App.xaml.cs
+++ b/PD2Launcherv2/App.xaml.cs
@@ -125,6 +125,8 @@ namespace PD2Launcherv2
                     }
 
                     launchGameHelpers.LaunchGame(localStorage);
+                    Shutdown();
+                    return;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
If you run launcher with --launch arg, it's process lingers after closing the game and you need to kill it manually. This closes it down after launching.